### PR TITLE
Fixed retain issue causing crash with launch on login

### DIFF
--- a/KeepingYouAwake/NSApplication+LoginItem.m
+++ b/KeepingYouAwake/NSApplication+LoginItem.m
@@ -39,6 +39,7 @@
     if(loginItem)
     {
         result = YES;
+        CFRelease(loginItem);
     }
     
     return result;
@@ -53,8 +54,8 @@
                                                                         kLSSharedFileListSessionLoginItems,
                                                                         NULL);
         LSSharedFileListItemRemove(loginItemsFileList,loginItem);
+
         CFRelease(loginItemsFileList);
-        
         CFRelease(loginItem);
     }
 }
@@ -106,6 +107,7 @@
             if([bundleURL isEqual:itemURL])
             {
                 loginItem = fileListItem;
+                CFRetain(loginItem);
             }
         }
         


### PR DESCRIPTION
```kya_retainedLoginItem``` was not actually retaining the login item it returned, resulted in BAD_ACCESS when start on login was unchecked. Fixes #26 