### PR TITLE
Sparkle XPC Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### v1.4.4 ###
 
 - added an Updates tab to preferences
-- updated Sparkle to the XPC version
+- updated Sparkle to the `ui-separation-and-xpc` version
 
 ### v1.4.3 ###
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### v1.4.4 ###
 
 - added an Updates tab to preferences
+- updated Sparkle to the XPC version
 
 ### v1.4.3 ###
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,0 @@
-# Sparkle
-github "sparkle-project/Sparkle" ~> 1.17.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,0 @@
-github "sparkle-project/Sparkle" "1.20.0"

--- a/KeepingYouAwake.xcodeproj/project.pbxproj
+++ b/KeepingYouAwake.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		DA0ADE6621CBFC5800D34B9D /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA0ADE6521CBFC5800D34B9D /* Sparkle.framework */; };
+		DA0ADE6821CBFC6000D34B9D /* Sparkle.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DA0ADE6521CBFC5800D34B9D /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		DA0ADE6E21CBFCA700D34B9D /* org.sparkle-project.Downloader.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = DA0ADE6A21CBFC9700D34B9D /* org.sparkle-project.Downloader.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		DA0ADE6F21CBFCA700D34B9D /* org.sparkle-project.InstallerConnection.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = DA0ADE6B21CBFC9700D34B9D /* org.sparkle-project.InstallerConnection.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		DA0ADE7021CBFCA700D34B9D /* org.sparkle-project.InstallerLauncher.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = DA0ADE6C21CBFC9700D34B9D /* org.sparkle-project.InstallerLauncher.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		DA0ADE7121CBFCA700D34B9D /* org.sparkle-project.InstallerStatus.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = DA0ADE6D21CBFC9700D34B9D /* org.sparkle-project.InstallerStatus.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		DA173B371F65B41B00932CE0 /* KYAStatusItemController.m in Sources */ = {isa = PBXBuildFile; fileRef = DA173B361F65B41B00932CE0 /* KYAStatusItemController.m */; };
 		DA2691D21B8231C700B15779 /* KYAMenuBarIcon.m in Sources */ = {isa = PBXBuildFile; fileRef = DA2691D11B8231C700B15779 /* KYAMenuBarIcon.m */; };
 		DA46C1EE1BDCDFB00050357C /* NSUserDefaults+Keys.m in Sources */ = {isa = PBXBuildFile; fileRef = DA46C1ED1BDCDFB00050357C /* NSUserDefaults+Keys.m */; };
@@ -35,12 +41,27 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		DA0ADE6921CBFC7E00D34B9D /* Embed XPC Services */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/XPCServices";
+			dstSubfolderSpec = 16;
+			files = (
+				DA0ADE6E21CBFCA700D34B9D /* org.sparkle-project.Downloader.xpc in Embed XPC Services */,
+				DA0ADE6F21CBFCA700D34B9D /* org.sparkle-project.InstallerConnection.xpc in Embed XPC Services */,
+				DA0ADE7021CBFCA700D34B9D /* org.sparkle-project.InstallerLauncher.xpc in Embed XPC Services */,
+				DA0ADE7121CBFCA700D34B9D /* org.sparkle-project.InstallerStatus.xpc in Embed XPC Services */,
+			);
+			name = "Embed XPC Services";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DA8CB49F1A5767CC00BC6F73 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				DA0ADE6821CBFC6000D34B9D /* Sparkle.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -56,6 +77,11 @@
 		8F6945C71DB7A87C0059C386 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		8F6945C81DB7A87D0059C386 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8F6945C91DB7A87D0059C386 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/MainMenu.strings; sourceTree = "<group>"; };
+		DA0ADE6521CBFC5800D34B9D /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sparkle.framework; path = Vendor/Sparkle/Sparkle.framework; sourceTree = "<group>"; };
+		DA0ADE6A21CBFC9700D34B9D /* org.sparkle-project.Downloader.xpc */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.xpc-service"; name = "org.sparkle-project.Downloader.xpc"; path = "Vendor/Sparkle/XPCServices/org.sparkle-project.Downloader.xpc"; sourceTree = "<group>"; };
+		DA0ADE6B21CBFC9700D34B9D /* org.sparkle-project.InstallerConnection.xpc */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.xpc-service"; name = "org.sparkle-project.InstallerConnection.xpc"; path = "Vendor/Sparkle/XPCServices/org.sparkle-project.InstallerConnection.xpc"; sourceTree = "<group>"; };
+		DA0ADE6C21CBFC9700D34B9D /* org.sparkle-project.InstallerLauncher.xpc */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.xpc-service"; name = "org.sparkle-project.InstallerLauncher.xpc"; path = "Vendor/Sparkle/XPCServices/org.sparkle-project.InstallerLauncher.xpc"; sourceTree = "<group>"; };
+		DA0ADE6D21CBFC9700D34B9D /* org.sparkle-project.InstallerStatus.xpc */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.xpc-service"; name = "org.sparkle-project.InstallerStatus.xpc"; path = "Vendor/Sparkle/XPCServices/org.sparkle-project.InstallerStatus.xpc"; sourceTree = "<group>"; };
 		DA173B351F65B41B00932CE0 /* KYAStatusItemController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KYAStatusItemController.h; sourceTree = "<group>"; };
 		DA173B361F65B41B00932CE0 /* KYAStatusItemController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KYAStatusItemController.m; sourceTree = "<group>"; };
 		DA249E281F9B7211006BCD2C /* KYADefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KYADefines.h; sourceTree = "<group>"; };
@@ -147,6 +173,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA0ADE6621CBFC5800D34B9D /* Sparkle.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -292,6 +319,11 @@
 		DA66CF9F1A12A7D700336CDC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				DA0ADE6521CBFC5800D34B9D /* Sparkle.framework */,
+				DA0ADE6A21CBFC9700D34B9D /* org.sparkle-project.Downloader.xpc */,
+				DA0ADE6B21CBFC9700D34B9D /* org.sparkle-project.InstallerConnection.xpc */,
+				DA0ADE6C21CBFC9700D34B9D /* org.sparkle-project.InstallerLauncher.xpc */,
+				DA0ADE6D21CBFC9700D34B9D /* org.sparkle-project.InstallerStatus.xpc */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -339,6 +371,7 @@
 				DA637B3619F14693004C8838 /* Frameworks */,
 				DA637B3719F14693004C8838 /* Resources */,
 				DA8CB49F1A5767CC00BC6F73 /* Embed Frameworks */,
+				DA0ADE6921CBFC7E00D34B9D /* Embed XPC Services */,
 			);
 			buildRules = (
 			);
@@ -653,7 +686,7 @@
 				DEVELOPMENT_TEAM = 5KESHV9W85;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
+					"$(PROJECT_DIR)/Vendor/Sparkle",
 				);
 				INFOPLIST_FILE = KeepingYouAwake/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
@@ -671,7 +704,7 @@
 				DEVELOPMENT_TEAM = 5KESHV9W85;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
+					"$(PROJECT_DIR)/Vendor/Sparkle",
 				);
 				INFOPLIST_FILE = KeepingYouAwake/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";

--- a/KeepingYouAwake.xcodeproj/project.pbxproj
+++ b/KeepingYouAwake.xcodeproj/project.pbxproj
@@ -25,8 +25,6 @@
 		DA637B5E19F146B6004C8838 /* KYAAppController.m in Sources */ = {isa = PBXBuildFile; fileRef = DA637B5D19F146B6004C8838 /* KYAAppController.m */; };
 		DA7B53061E16999A00D89A12 /* KYAPreferencesWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = DA7B53051E16999A00D89A12 /* KYAPreferencesWindowController.m */; };
 		DA82B1161C2426E400FA46E0 /* KYAGeneralPreferencesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DA82B1151C2426E400FA46E0 /* KYAGeneralPreferencesViewController.m */; };
-		DA8CB49D1A5767CC00BC6F73 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA7931C31A575C6000B6DEC4 /* Sparkle.framework */; };
-		DA8CB49E1A5767CC00BC6F73 /* Sparkle.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DA7931C31A575C6000B6DEC4 /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DAB128691C2453F600831045 /* KYAAdvancedPreferencesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DAB128681C2453F600831045 /* KYAAdvancedPreferencesViewController.m */; };
 		DAB1286C1C24540200831045 /* KYAAboutPreferencesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DAB1286B1C24540200831045 /* KYAAboutPreferencesViewController.m */; };
 		DAB128711C245F1B00831045 /* NSApplication+Versions.m in Sources */ = {isa = PBXBuildFile; fileRef = DAB128701C245F1B00831045 /* NSApplication+Versions.m */; };
@@ -43,7 +41,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				DA8CB49E1A5767CC00BC6F73 /* Sparkle.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -113,7 +110,6 @@
 		DA66277520CC0693007834DB /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		DA66277620CC0695007834DB /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		DA753D391C3714A800955BE3 /* KYABatteryCapacityThreshold.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KYABatteryCapacityThreshold.h; sourceTree = "<group>"; };
-		DA7931C31A575C6000B6DEC4 /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sparkle.framework; path = Carthage/Build/Mac/Sparkle.framework; sourceTree = SOURCE_ROOT; };
 		DA7B53041E16999A00D89A12 /* KYAPreferencesWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KYAPreferencesWindowController.h; sourceTree = "<group>"; };
 		DA7B53051E16999A00D89A12 /* KYAPreferencesWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KYAPreferencesWindowController.m; sourceTree = "<group>"; };
 		DA7C2E161E2159D200B84F59 /* Configuration.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Configuration.xcconfig; sourceTree = SOURCE_ROOT; };
@@ -151,7 +147,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DA8CB49D1A5767CC00BC6F73 /* Sparkle.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -297,10 +292,8 @@
 		DA66CF9F1A12A7D700336CDC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				DA7931C31A575C6000B6DEC4 /* Sparkle.framework */,
 			);
 			name = Frameworks;
-			path = KeepingYouAwake;
 			sourceTree = "<group>";
 		};
 		DA82B1111C2422F600FA46E0 /* Preferences */ = {
@@ -345,7 +338,6 @@
 				DA637B3519F14693004C8838 /* Sources */,
 				DA637B3619F14693004C8838 /* Frameworks */,
 				DA637B3719F14693004C8838 /* Resources */,
-				DA4C74361A5763B000BE1BE1 /* Carthage Copy Frameworks */,
 				DA8CB49F1A5767CC00BC6F73 /* Embed Frameworks */,
 			);
 			buildRules = (
@@ -364,7 +356,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = KYA;
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1010;
 				ORGANIZATIONNAME = "Marcel Dierkes";
 				TargetAttributes = {
 					DA637B3819F14693004C8838 = {
@@ -410,24 +402,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		DA4C74361A5763B000BE1BE1 /* Carthage Copy Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/Mac/Sparkle.framework",
-			);
-			name = "Carthage Copy Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = /usr/local/bin/carthage;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		DA637B3519F14693004C8838 /* Sources */ = {

--- a/KeepingYouAwake.xcodeproj/xcshareddata/xcschemes/KeepingYouAwake.xcscheme
+++ b/KeepingYouAwake.xcodeproj/xcshareddata/xcschemes/KeepingYouAwake.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1010"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/KeepingYouAwake/Base.lproj/MainMenu.xib
+++ b/KeepingYouAwake/Base.lproj/MainMenu.xib
@@ -19,6 +19,11 @@
                 <outlet property="timerMenu" destination="uTe-0S-BFw" id="uJl-Rb-elA"/>
             </connections>
         </customObject>
+        <customObject id="JNo-z8-htK" customClass="SPUStandardUpdaterController">
+            <connections>
+                <outlet property="updaterDelegate" destination="Voe-Tx-rLC" id="fMf-4e-s3F"/>
+            </connections>
+        </customObject>
         <menu id="RrS-wX-j75">
             <items>
                 <menuItem title="Activate for Duration" id="Bo6-IE-IbX">

--- a/KeepingYouAwake/Base.lproj/MainMenu.xib
+++ b/KeepingYouAwake/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -17,11 +17,6 @@
             <connections>
                 <outlet property="menu" destination="RrS-wX-j75" id="Qkd-Lu-ekl"/>
                 <outlet property="timerMenu" destination="uTe-0S-BFw" id="uJl-Rb-elA"/>
-            </connections>
-        </customObject>
-        <customObject id="8QH-MG-rpV" customClass="SUUpdater">
-            <connections>
-                <outlet property="delegate" destination="Voe-Tx-rLC" id="UqK-d2-hFU"/>
             </connections>
         </customObject>
         <menu id="RrS-wX-j75">

--- a/KeepingYouAwake/Info.plist
+++ b/KeepingYouAwake/Info.plist
@@ -39,11 +39,6 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>
 	<true/>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>${KYA_COPYRIGHT_TEXT}</string>
 	<key>NSMainNibFile</key>

--- a/KeepingYouAwake/KYAAppDelegate.m
+++ b/KeepingYouAwake/KYAAppDelegate.m
@@ -7,11 +7,10 @@
 //
 
 #import "KYAAppDelegate.h"
-#import <Sparkle/Sparkle.h>
 #import "NSUserDefaults+Keys.h"
 #import "KYAPreferencesWindowController.h"
 
-@interface KYAAppDelegate () <NSWindowDelegate, SUUpdaterDelegate>
+@interface KYAAppDelegate () <NSWindowDelegate/*, SUUpdaterDelegate*/>
 @property (nonatomic, nullable) KYAPreferencesWindowController *preferencesWindowController;
 @end
 
@@ -43,21 +42,21 @@
     self.preferencesWindowController = nil;
 }
 
-#pragma mark - Updater Delegate
-
-- (NSString *)feedURLStringForUpdater:(SUUpdater *)updater
-{
-    NSString *feedURLString = NSBundle.mainBundle.infoDictionary[@"SUFeedURL"];
-    NSAssert(feedURLString != nil, @"A feed URL should be set in Info.plist");
-    
-    if([NSUserDefaults.standardUserDefaults kya_arePreReleaseUpdatesEnabled])
-    {
-        NSString *lastComponent = feedURLString.lastPathComponent;
-        NSString *baseURLString = feedURLString.stringByDeletingLastPathComponent;
-        return [NSString stringWithFormat:@"%@/prerelease-%@", baseURLString, lastComponent];
-    }
-    
-    return feedURLString;
-}
+//#pragma mark - Updater Delegate
+//
+//- (NSString *)feedURLStringForUpdater:(SUUpdater *)updater
+//{
+//    NSString *feedURLString = NSBundle.mainBundle.infoDictionary[@"SUFeedURL"];
+//    NSAssert(feedURLString != nil, @"A feed URL should be set in Info.plist");
+//
+//    if([NSUserDefaults.standardUserDefaults kya_arePreReleaseUpdatesEnabled])
+//    {
+//        NSString *lastComponent = feedURLString.lastPathComponent;
+//        NSString *baseURLString = feedURLString.stringByDeletingLastPathComponent;
+//        return [NSString stringWithFormat:@"%@/prerelease-%@", baseURLString, lastComponent];
+//    }
+//
+//    return feedURLString;
+//}
 
 @end

--- a/KeepingYouAwake/KYAAppDelegate.m
+++ b/KeepingYouAwake/KYAAppDelegate.m
@@ -7,10 +7,11 @@
 //
 
 #import "KYAAppDelegate.h"
+#import <Sparkle/Sparkle.h>
 #import "NSUserDefaults+Keys.h"
 #import "KYAPreferencesWindowController.h"
 
-@interface KYAAppDelegate () <NSWindowDelegate/*, SUUpdaterDelegate*/>
+@interface KYAAppDelegate () <NSWindowDelegate, SPUUpdaterDelegate>
 @property (nonatomic, nullable) KYAPreferencesWindowController *preferencesWindowController;
 @end
 
@@ -42,21 +43,21 @@
     self.preferencesWindowController = nil;
 }
 
-//#pragma mark - Updater Delegate
-//
-//- (NSString *)feedURLStringForUpdater:(SUUpdater *)updater
-//{
-//    NSString *feedURLString = NSBundle.mainBundle.infoDictionary[@"SUFeedURL"];
-//    NSAssert(feedURLString != nil, @"A feed URL should be set in Info.plist");
-//
-//    if([NSUserDefaults.standardUserDefaults kya_arePreReleaseUpdatesEnabled])
-//    {
-//        NSString *lastComponent = feedURLString.lastPathComponent;
-//        NSString *baseURLString = feedURLString.stringByDeletingLastPathComponent;
-//        return [NSString stringWithFormat:@"%@/prerelease-%@", baseURLString, lastComponent];
-//    }
-//
-//    return feedURLString;
-//}
+#pragma mark - SPUUpdaterDelegate
+
+- (NSString *)feedURLStringForUpdater:(SPUUpdater *)updater
+{
+    NSString *feedURLString = NSBundle.mainBundle.infoDictionary[@"SUFeedURL"];
+    NSAssert(feedURLString != nil, @"A feed URL should be set in Info.plist");
+
+    if([NSUserDefaults.standardUserDefaults kya_arePreReleaseUpdatesEnabled])
+    {
+        NSString *lastComponent = feedURLString.lastPathComponent;
+        NSString *baseURLString = feedURLString.stringByDeletingLastPathComponent;
+        return [NSString stringWithFormat:@"%@/prerelease-%@", baseURLString, lastComponent];
+    }
+
+    return feedURLString;
+}
 
 @end

--- a/KeepingYouAwake/Preferences/Base.lproj/Preferences.storyboard
+++ b/KeepingYouAwake/Preferences/Base.lproj/Preferences.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="uZF-hQ-SQu">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="uZF-hQ-SQu">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -564,9 +564,6 @@
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
                                             </buttonCell>
-                                            <connections>
-                                                <binding destination="dyt-Ah-m7v" name="value" keyPath="automaticallyChecksForUpdates" id="CAa-HC-mvB"/>
-                                            </connections>
                                         </button>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yqL-TQ-Yyq">
                                             <rect key="frame" x="192" y="15" width="109" height="32"/>
@@ -574,9 +571,6 @@
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="system"/>
                                             </buttonCell>
-                                            <connections>
-                                                <action selector="checkForUpdates:" target="dyt-Ah-m7v" id="KDR-Jp-sYp"/>
-                                            </connections>
                                         </button>
                                     </subviews>
                                     <constraints>
@@ -609,17 +603,16 @@
                     </view>
                 </viewController>
                 <customObject id="zmq-SH-iwA" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
-                <customObject id="dyt-Ah-m7v" customClass="SUUpdater"/>
                 <userDefaultsController id="4Au-If-gob"/>
             </objects>
             <point key="canvasLocation" x="-228" y="1168"/>
         </scene>
     </scenes>
     <resources>
-        <image name="NSAdvanced" width="128" height="128"/>
-        <image name="NSApplicationIcon" width="128" height="128"/>
-        <image name="NSNetwork" width="128" height="128"/>
-        <image name="NSPreferencesGeneral" width="128" height="128"/>
+        <image name="NSAdvanced" width="32" height="32"/>
+        <image name="NSApplicationIcon" width="32" height="32"/>
+        <image name="NSNetwork" width="32" height="32"/>
+        <image name="NSPreferencesGeneral" width="32" height="32"/>
         <image name="NSRefreshFreestandingTemplate" width="14" height="14"/>
     </resources>
 </document>

--- a/KeepingYouAwake/Preferences/Base.lproj/Preferences.storyboard
+++ b/KeepingYouAwake/Preferences/Base.lproj/Preferences.storyboard
@@ -564,6 +564,9 @@
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
                                             </buttonCell>
+                                            <connections>
+                                                <binding destination="Zv3-Yg-TMp" name="value" keyPath="self.updater.automaticallyChecksForUpdates" id="o18-Ak-N98"/>
+                                            </connections>
                                         </button>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yqL-TQ-Yyq">
                                             <rect key="frame" x="192" y="15" width="109" height="32"/>
@@ -571,6 +574,9 @@
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="system"/>
                                             </buttonCell>
+                                            <connections>
+                                                <action selector="checkForUpdates:" target="Zv3-Yg-TMp" id="IkN-en-yJr"/>
+                                            </connections>
                                         </button>
                                     </subviews>
                                     <constraints>
@@ -603,6 +609,7 @@
                     </view>
                 </viewController>
                 <customObject id="zmq-SH-iwA" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+                <customObject id="Zv3-Yg-TMp" customClass="SPUStandardUpdaterController"/>
                 <userDefaultsController id="4Au-If-gob"/>
             </objects>
             <point key="canvasLocation" x="-228" y="1168"/>

--- a/Makefile
+++ b/Makefile
@@ -3,21 +3,22 @@ WORKSPACE = KeepingYouAwake.xcworkspace
 VERSION = 1.4.3
 
 OUTPUT_DIR = dist
-CARTHAGE_DIR = Carthage
+VENDOR_DIR = Vendor
 
 FASTLANE = FASTLANE_SKIP_UPDATE_CHECK=1 FASTLANE_DISABLE_ANIMATION=1 fastlane
 
 default: dist
 
 clean:
-	rm -rf build
-	rm -rf $(CARTHAGE_DIR)
-	rm -rf $(OUTPUT_DIR)
+	$(RM) -r build
+	$(RM) -r $(OUTPUT_DIR)
+	$(MAKE) -C $(VENDOR_DIR) clean
 
-$(CARTHAGE_DIR):
-	carthage bootstrap --use-ssh --platform macOS
+$(VENDOR_DIR):
+	$(MAKE) -C $(VENDOR_DIR)
 
-$(OUTPUT_DIR)/$(SCHEME).app: $(CARTHAGE_DIR)
+$(OUTPUT_DIR)/$(SCHEME).app: $(VENDOR_DIR)
+	$(MAKE) $(VENDOR_DIR)
 	$(FASTLANE) gym \
 	--workspace $(WORKSPACE) \
 	--scheme $(SCHEME) \
@@ -37,4 +38,4 @@ clangformat:
 	$(info Reformatting source files with clang-format...)
 	clang-format -style=file -i $(shell pwd)/**/*.{h,m}
 
-.PHONY: clean dist clang-format
+.PHONY: clean dist $(VENDOR_DIR) clang-format

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ default: dist
 clean:
 	$(RM) -r build
 	$(RM) -r $(OUTPUT_DIR)
-	$(MAKE) -C $(VENDOR_DIR) clean
 
 $(VENDOR_DIR):
 	$(MAKE) -C $(VENDOR_DIR)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Do you want to improve the app or add useful features? Please go ahead and creat
 
 ## Building the Source Code
 
-*KeepingYouAwake* uses [Carthage](https://github.com/Carthage/Carthage) as dependency manager. You can install Carthage with [Homebrew](http://brew.sh). Type `brew update && brew install carthage` and call `carthage bootstrap` in the *KeepingYouAwake* source code folder to download and build all dependencies.
+*KeepingYouAwake* uses [Sparkle](https://github.com/sparkle-project/Sparkle/tree/ui-separation-and-xpc)'s `ui-separation-and-xpc` branch to deliver updates. You can build and sign Sparkle with `make Vendor`. To build a release version of the app just run `make dist`.
 
 ## License
 

--- a/Vendor/.gitignore
+++ b/Vendor/.gitignore
@@ -1,0 +1,2 @@
+build
+Sparkle

--- a/Vendor/Makefile
+++ b/Vendor/Makefile
@@ -1,0 +1,24 @@
+BUILD_DIR = build
+REPO_DIR = $(BUILD_DIR)/Sparkle
+DIST_DIR = Sparkle
+
+default: $(DIST_DIR)
+
+clean:
+	$(RM) -r $(BUILD_DIR)
+	$(RM) -r $(DIST_DIR)
+
+$(REPO_DIR):
+	mkdir -p $(BUILD_DIR)
+	git clone git@github.com:sparkle-project/Sparkle.git $(REPO_DIR)
+	cd $(REPO_DIR) && git checkout ui-separation-and-xpc
+
+$(DIST_DIR): $(REPO_DIR)
+	mkdir -p $(DIST_DIR)
+	cd $(REPO_DIR) && xcodebuild \
+		-scheme Distribution \
+		-configuration Release \
+		-derivedDataPath "../$(BUILD_DIR)" \
+		build
+	cd $(DIST_DIR) && tar xfvj ../$(BUILD_DIR)/build/Build/Products/Release/Sparkle-*.tar.bz2
+	$(DIST_DIR)/bin/codesign_xpc "Developer ID Application" $(DIST_DIR)/XPCServices/*.xpc

--- a/Vendor/Makefile
+++ b/Vendor/Makefile
@@ -2,6 +2,8 @@ BUILD_DIR = build
 REPO_DIR = $(BUILD_DIR)/Sparkle
 DIST_DIR = Sparkle
 
+SPARKLE_COMMIT = b1c3b313f53c95a91c8adc07b991ff9a306e6cf8 # ui-separation-and-xpc
+
 default: $(DIST_DIR)
 
 clean:
@@ -11,7 +13,7 @@ clean:
 $(REPO_DIR):
 	mkdir -p $(BUILD_DIR)
 	git clone git@github.com:sparkle-project/Sparkle.git $(REPO_DIR)
-	cd $(REPO_DIR) && git checkout ui-separation-and-xpc
+	cd $(REPO_DIR) && git checkout $(SPARKLE_COMMIT)
 
 $(DIST_DIR): $(REPO_DIR)
 	mkdir -p $(DIST_DIR)


### PR DESCRIPTION
- replaced stable Sparkle with the [`ui-separation-and-xpc`](https://github.com/sparkle-project/Sparkle/tree/ui-separation-and-xpc) fork that provides XPC services that can be sandboxed
- removed Carthage integration since Sparkle is not compatible anymore
- removed the `Info.plist` `NSAppTransportSecurity` key, since we don't need any overrides
- added a custom `Vendor/Makefile` to checkout, build and codesign Sparkle