### PR TITLE
Hardened Runtime Support and Notarization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - _Start at login_ uses a launcher helper app now ([#110](https://github.com/newmarcel/KeepingYouAwake/pull/110))
     - the previous login item is not compatible anymore and **it is recommended to disable _Start at login_ before updating**!
     - please check this [Wiki page](https://github.com/newmarcel/KeepingYouAwake/wiki/1.5:-Start-at-Login-Problems) if you encounter problems
+- enabled the Hardened Runtime security feature 
 
 ### v1.4.3 ###
 

--- a/Configuration.xcconfig
+++ b/Configuration.xcconfig
@@ -11,4 +11,4 @@ PRODUCT_BUNDLE_IDENTIFIER = info.marcel-dierkes.KeepingYouAwake
 
 KYA_COPYRIGHT_TEXT = Copyright © 2014 – 2018 Marcel Dierkes. All rights reserved.
 KYA_BUNDLE_VERSION = 1.4.4pre
-KYA_BUILD_NUMBER = 1040402
+KYA_BUILD_NUMBER = 1040403

--- a/Configuration.xcconfig
+++ b/Configuration.xcconfig
@@ -11,4 +11,4 @@ PRODUCT_BUNDLE_IDENTIFIER = info.marcel-dierkes.KeepingYouAwake
 
 KYA_COPYRIGHT_TEXT = Copyright © 2014 – 2018 Marcel Dierkes. All rights reserved.
 KYA_BUNDLE_VERSION = 1.4.4pre
-KYA_BUILD_NUMBER = 1040403
+KYA_BUILD_NUMBER = 1040404

--- a/Configuration.xcconfig
+++ b/Configuration.xcconfig
@@ -11,4 +11,4 @@ PRODUCT_BUNDLE_IDENTIFIER = info.marcel-dierkes.KeepingYouAwake
 
 KYA_COPYRIGHT_TEXT = Copyright © 2014 – 2018 Marcel Dierkes. All rights reserved.
 KYA_BUNDLE_VERSION = 1.4.4pre
-KYA_BUILD_NUMBER = 1040401
+KYA_BUILD_NUMBER = 1040402

--- a/Configuration.xcconfig
+++ b/Configuration.xcconfig
@@ -11,4 +11,4 @@ PRODUCT_BUNDLE_IDENTIFIER = info.marcel-dierkes.KeepingYouAwake
 
 KYA_COPYRIGHT_TEXT = Copyright © 2014 – 2018 Marcel Dierkes. All rights reserved.
 KYA_BUNDLE_VERSION = 1.4.4pre
-KYA_BUILD_NUMBER = 1040404
+KYA_BUILD_NUMBER = 1040406

--- a/Configuration.xcconfig
+++ b/Configuration.xcconfig
@@ -11,4 +11,4 @@ PRODUCT_BUNDLE_IDENTIFIER = info.marcel-dierkes.KeepingYouAwake
 
 KYA_COPYRIGHT_TEXT = Copyright © 2014 – 2018 Marcel Dierkes. All rights reserved.
 KYA_BUNDLE_VERSION = 1.4.4pre
-KYA_BUILD_NUMBER = 1040406
+KYA_BUILD_NUMBER = 1040407

--- a/Extras/Stapler.sh
+++ b/Extras/Stapler.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+##
+## Usage:
+## - Stapler.sh notarize <username>
+## - Stapler.sh staple <version_number>
+##
+## Fighting Notarization Issues:
+## https://developer.apple.com/documentation/security/notarizing_your_app_before_distribution/resolving_common_notarization_issues?language=objc
+##
+set -e
+
+COMMAND="${1}"
+
+function notarize {
+    local account="${1}"
+    echo "Notarizing KeepingYouAwake.app using ${account}..."
+    xcrun altool \
+        --type osx \
+        --file dist/KeepingYouAwake-*.zip \
+        --primary-bundle-id info.marcel-dierkes.KeepingYouAwake \
+        --notarize-app \
+        --username "${account}"
+}
+
+if [[ "${COMMAND}" == "notarize" ]]; then
+    notarize ${2}
+fi
+
+# function info {
+#     local request_id="${1}"
+#     local account="${2}"
+#     echo "Getting Notarization Info for ${request_id} using ${account}..."
+#     xcrun altool \
+#         –-notarization-info ${request_id} \
+#         --username "${account}"
+# }
+
+# if [[ "${COMMAND}" == "info" ]]; then
+#     info ${2} ${3}
+# fi
+
+function staple {
+    xcrun stapler staple -v dist/KeepingYouAwake.app
+    spctl -a -vv dist/KeepingYouAwake.app
+}
+
+# Takes the app version as parameter
+function repack {
+    local version="${1}"
+    ditto -c -k --sequesterRsrc --keepParent dist/KeepingYouAwake.app dist/KeepingYouAwake-${version}.zip
+}
+
+if [[ "${COMMAND}" == "staple" ]]; then
+    staple
+    repack ${2}
+fi

--- a/KeepingYouAwake.xcodeproj/project.pbxproj
+++ b/KeepingYouAwake.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		DA0ADE6B21CBFC9700D34B9D /* org.sparkle-project.InstallerConnection.xpc */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.xpc-service"; name = "org.sparkle-project.InstallerConnection.xpc"; path = "Vendor/Sparkle/XPCServices/org.sparkle-project.InstallerConnection.xpc"; sourceTree = "<group>"; };
 		DA0ADE6C21CBFC9700D34B9D /* org.sparkle-project.InstallerLauncher.xpc */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.xpc-service"; name = "org.sparkle-project.InstallerLauncher.xpc"; path = "Vendor/Sparkle/XPCServices/org.sparkle-project.InstallerLauncher.xpc"; sourceTree = "<group>"; };
 		DA0ADE6D21CBFC9700D34B9D /* org.sparkle-project.InstallerStatus.xpc */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.xpc-service"; name = "org.sparkle-project.InstallerStatus.xpc"; path = "Vendor/Sparkle/XPCServices/org.sparkle-project.InstallerStatus.xpc"; sourceTree = "<group>"; };
+		DA0CA9FE21D0111600879C8B /* KeepingYouAwake.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = KeepingYouAwake.entitlements; sourceTree = "<group>"; };
 		DA173B351F65B41B00932CE0 /* KYAStatusItemController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KYAStatusItemController.h; sourceTree = "<group>"; };
 		DA173B361F65B41B00932CE0 /* KYAStatusItemController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KYAStatusItemController.m; sourceTree = "<group>"; };
 		DA249E281F9B7211006BCD2C /* KYADefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KYADefines.h; sourceTree = "<group>"; };
@@ -335,6 +336,7 @@
 				DA637B5D19F146B6004C8838 /* KYAAppController.m */,
 				DAB268701A0D6BC600B58AD6 /* KYASleepWakeTimer.h */,
 				DAB268711A0D6BC600B58AD6 /* KYASleepWakeTimer.m */,
+				DA0CA9FE21D0111600879C8B /* KeepingYouAwake.entitlements */,
 				DA82B1111C2422F600FA46E0 /* Preferences */,
 				DA8F381B1F9BA4360086A84A /* StatusItemController */,
 				DA2691CF1B8230AB00B15779 /* MenuBar Icon */,
@@ -473,11 +475,21 @@
 						CreatedOnToolsVersion = 6.0.1;
 						DevelopmentTeam = 5KESHV9W85;
 						ProvisioningStyle = Manual;
+						SystemCapabilities = {
+							com.apple.HardenedRuntime = {
+								enabled = 1;
+							};
+						};
 					};
 					DA658E6A21CE907B0049F4C1 = {
 						CreatedOnToolsVersion = 10.1;
 						DevelopmentTeam = 5KESHV9W85;
 						ProvisioningStyle = Manual;
+						SystemCapabilities = {
+							com.apple.HardenedRuntime = {
+								enabled = 1;
+							};
+						};
 					};
 				};
 			};
@@ -793,6 +805,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = 5KESHV9W85;
+				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Vendor/Sparkle",
@@ -811,6 +824,7 @@
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = 5KESHV9W85;
+				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Vendor/Sparkle",
@@ -839,6 +853,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 5KESHV9W85;
+				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = KYALauncher/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
@@ -868,6 +883,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEVELOPMENT_TEAM = 5KESHV9W85;
+				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = KYALauncher/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MTL_FAST_MATH = YES;

--- a/KeepingYouAwake.xcodeproj/project.pbxproj
+++ b/KeepingYouAwake.xcodeproj/project.pbxproj
@@ -432,7 +432,6 @@
 				DA8CB49F1A5767CC00BC6F73 /* Embed Frameworks */,
 				DA658E8321CE93120049F4C1 /* Embed Launcher */,
 				DA0ADE6921CBFC7E00D34B9D /* Embed XPC Services */,
-				DACD32A22188635B00263C40 /* Harden Sparkle Runtime */,
 			);
 			buildRules = (
 			);
@@ -540,27 +539,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		DACD32A22188635B00263C40 /* Harden Sparkle Runtime */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 8;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Harden Sparkle Runtime";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 1;
-			shellPath = /bin/sh;
-			shellScript = "# Source: https://github.com/sparkle-project/Sparkle/issues/1266#issuecomment-421182578\nLOCATION=\"${BUILT_PRODUCTS_DIR}\"/\"${FRAMEWORKS_FOLDER_PATH}\"\n\n# By default, use the configured code signing identity for the project/target\nIDENTITY=\"${CODE_SIGN_IDENTITY}\"\nif [ \"$IDENTITY\" == \"\" ]\nthen\n# If a code signing identity is not specified, use ad hoc signing\nIDENTITY=\"-\"\nfi\ncodesign --verbose --force --deep -o runtime --sign \"$IDENTITY\" \"$LOCATION/Sparkle.framework/Versions/A/Resources/Autoupdate\"\ncodesign --verbose --force --deep -o runtime --sign \"$IDENTITY\" \"$LOCATION/Sparkle.framework/Versions/A/Resources/Updater.app\"\ncodesign --verbose --force -o runtime --sign \"$IDENTITY\" \"$LOCATION/Sparkle.framework/Versions/A\"\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		DA637B3519F14693004C8838 /* Sources */ = {

--- a/KeepingYouAwake.xcodeproj/project.pbxproj
+++ b/KeepingYouAwake.xcodeproj/project.pbxproj
@@ -432,6 +432,7 @@
 				DA8CB49F1A5767CC00BC6F73 /* Embed Frameworks */,
 				DA658E8321CE93120049F4C1 /* Embed Launcher */,
 				DA0ADE6921CBFC7E00D34B9D /* Embed XPC Services */,
+				DACD32A22188635B00263C40 /* Harden Sparkle Runtime */,
 			);
 			buildRules = (
 			);
@@ -539,6 +540,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		DACD32A22188635B00263C40 /* Harden Sparkle Runtime */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 8;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Harden Sparkle Runtime";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+			shellPath = /bin/sh;
+			shellScript = "# Source: https://github.com/sparkle-project/Sparkle/issues/1266#issuecomment-421182578\nLOCATION=\"${BUILT_PRODUCTS_DIR}\"/\"${FRAMEWORKS_FOLDER_PATH}\"\n\n# By default, use the configured code signing identity for the project/target\nIDENTITY=\"${CODE_SIGN_IDENTITY}\"\nif [ \"$IDENTITY\" == \"\" ]\nthen\n# If a code signing identity is not specified, use ad hoc signing\nIDENTITY=\"-\"\nfi\ncodesign --verbose --force --deep -o runtime --sign \"$IDENTITY\" \"$LOCATION/Sparkle.framework/Versions/A/Resources/Autoupdate\"\ncodesign --verbose --force --deep -o runtime --sign \"$IDENTITY\" \"$LOCATION/Sparkle.framework/Versions/A/Resources/Updater.app\"\ncodesign --verbose --force -o runtime --sign \"$IDENTITY\" \"$LOCATION/Sparkle.framework/Versions/A\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		DA637B3519F14693004C8838 /* Sources */ = {

--- a/KeepingYouAwake.xcodeproj/project.pbxproj
+++ b/KeepingYouAwake.xcodeproj/project.pbxproj
@@ -336,7 +336,6 @@
 				DA637B5D19F146B6004C8838 /* KYAAppController.m */,
 				DAB268701A0D6BC600B58AD6 /* KYASleepWakeTimer.h */,
 				DAB268711A0D6BC600B58AD6 /* KYASleepWakeTimer.m */,
-				DA0CA9FE21D0111600879C8B /* KeepingYouAwake.entitlements */,
 				DA82B1111C2422F600FA46E0 /* Preferences */,
 				DA8F381B1F9BA4360086A84A /* StatusItemController */,
 				DA2691CF1B8230AB00B15779 /* MenuBar Icon */,
@@ -353,6 +352,7 @@
 			children = (
 				DA54C1331D69CA0000AF9E9D /* InfoPlist.strings */,
 				DA54C12C1D69C55400AF9E9D /* Localizable.strings */,
+				DA0CA9FE21D0111600879C8B /* KeepingYouAwake.entitlements */,
 				DA637B3D19F14693004C8838 /* Info.plist */,
 				DA637B3E19F14693004C8838 /* main.m */,
 				DA7C2E161E2159D200B84F59 /* Configuration.xcconfig */,

--- a/KeepingYouAwake.xcodeproj/project.pbxproj
+++ b/KeepingYouAwake.xcodeproj/project.pbxproj
@@ -822,6 +822,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = 5KESHV9W85;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -831,6 +832,7 @@
 				);
 				INFOPLIST_FILE = KeepingYouAwake/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				OTHER_CODE_SIGN_FLAGS = "$(inherited) --timestamp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
@@ -879,6 +881,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = KYALauncher/KYALauncher.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
@@ -887,6 +890,7 @@
 				INFOPLIST_FILE = KYALauncher/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MTL_FAST_MATH = YES;
+				OTHER_CODE_SIGN_FLAGS = "$(inherited) --timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = "info.marcel-dierkes.KeepingYouAwake.Launcher";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/KeepingYouAwake/KeepingYouAwake.entitlements
+++ b/KeepingYouAwake/KeepingYouAwake.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SCHEME = KeepingYouAwake
 WORKSPACE = KeepingYouAwake.xcworkspace
-VERSION = 1.4.3
+VERSION = 1.4.4pre
 
 OUTPUT_DIR = dist
 VENDOR_DIR = Vendor

--- a/Vendor/Makefile
+++ b/Vendor/Makefile
@@ -2,6 +2,9 @@ BUILD_DIR = build
 REPO_DIR = $(BUILD_DIR)/Sparkle
 DIST_DIR = Sparkle
 
+CODESIGN_IDENTITY = Developer ID Application
+CODESIGN_CMD = codesign --verbose --force -o runtime --sign "$(CODESIGN_IDENTITY)"
+
 SPARKLE_COMMIT = b1c3b313f53c95a91c8adc07b991ff9a306e6cf8 # ui-separation-and-xpc
 
 default: $(DIST_DIR)
@@ -23,5 +26,12 @@ $(DIST_DIR): $(REPO_DIR)
 		-derivedDataPath "../$(BUILD_DIR)" \
 		build
 	cd $(DIST_DIR) && tar xfvj ../$(BUILD_DIR)/build/Build/Products/Release/Sparkle-*.tar.bz2
+
+	# Codesign Updater Binaries
+	$(CODESIGN_CMD) --deep "$(DIST_DIR)/Sparkle.framework/Versions/A/Resources/Autoupdate"
+	$(CODESIGN_CMD) --deep "$(DIST_DIR)/Sparkle.framework/Versions/A/Resources/Updater.app"
+	$(CODESIGN_CMD) "$(DIST_DIR)/Sparkle.framework/Versions/A"
+
+	# Codesign XPC Services
 	patch $(DIST_DIR)/bin/codesign_xpc < codesign_xpc_hardened.patch
-	$(DIST_DIR)/bin/codesign_xpc "Developer ID Application" $(DIST_DIR)/XPCServices/*.xpc
+	$(DIST_DIR)/bin/codesign_xpc "$(CODESIGN_IDENTITY)" $(DIST_DIR)/XPCServices/*.xpc

--- a/Vendor/Makefile
+++ b/Vendor/Makefile
@@ -23,4 +23,5 @@ $(DIST_DIR): $(REPO_DIR)
 		-derivedDataPath "../$(BUILD_DIR)" \
 		build
 	cd $(DIST_DIR) && tar xfvj ../$(BUILD_DIR)/build/Build/Products/Release/Sparkle-*.tar.bz2
+	patch $(DIST_DIR)/bin/codesign_xpc < codesign_xpc_hardened.patch
 	$(DIST_DIR)/bin/codesign_xpc "Developer ID Application" $(DIST_DIR)/XPCServices/*.xpc

--- a/Vendor/codesign_xpc_hardened.patch
+++ b/Vendor/codesign_xpc_hardened.patch
@@ -1,0 +1,11 @@
+--- codesign_xpc	2018-12-28 11:30:57.000000000 +0100
++++ codesign_xpc.new	2018-12-28 11:31:01.000000000 +0100
+@@ -10,7 +10,7 @@
+     return ('"' + argument + '"' if ' ' in argument else argument)
+ 
+ def _codesign_service(identity, path, entitlements_path=None):
+-    command = ["codesign", "-fs", identity, path] + ([] if entitlements_path is None else ["--entitlements", entitlements_path])
++    command = ["codesign", "-o", "runtime", "-fs", identity, path] + ([] if entitlements_path is None else ["--entitlements", entitlements_path])
+     log_message(" ".join(map(sanitize, command)))
+ 
+     process = subprocess.Popen(command, stdout=subprocess.PIPE)


### PR DESCRIPTION
- enabled _Hardened Runtime_ for Sparkle services and binaries
- enabled _Hardened Runtime_ for the main app and the launcher
- added the ability to notarize using the command line
  - added `--timestamp` codesign flags for RELEASE builds
  - disabled `CODE_SIGN_INJECT_BASE_ENTITLEMENTS` for RELEASE builds
- added `Extras/Stapler.sh` to help me with notarization after running `make dist`