### PR TITLE
Fix Pre-release Check & Remove Redundant Sparkle Binaries

### DIFF
--- a/KeepingYouAwake/Preferences/Base.lproj/Preferences.storyboard
+++ b/KeepingYouAwake/Preferences/Base.lproj/Preferences.storyboard
@@ -529,7 +529,7 @@
         <!--Updates-->
         <scene sceneID="GLC-gz-Zi5">
             <objects>
-                <viewController title="Updates" id="8V0-Sq-Cdu" customClass="KYAUpdatePreferencesViewController" sceneMemberID="viewController">
+                <viewController title="Updates" id="8V0-Sq-Cdu" userLabel="Updates" customClass="KYAUpdatePreferencesViewController" sceneMemberID="viewController">
                     <view key="view" id="FTE-58-nDl">
                         <rect key="frame" x="0.0" y="0.0" width="451" height="146"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -609,7 +609,11 @@
                     </view>
                 </viewController>
                 <customObject id="zmq-SH-iwA" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
-                <customObject id="Zv3-Yg-TMp" customClass="SPUStandardUpdaterController"/>
+                <customObject id="Zv3-Yg-TMp" customClass="SPUStandardUpdaterController">
+                    <connections>
+                        <outlet property="updaterDelegate" destination="8V0-Sq-Cdu" id="i45-pG-Fxv"/>
+                    </connections>
+                </customObject>
                 <userDefaultsController id="4Au-If-gob"/>
             </objects>
             <point key="canvasLocation" x="-228" y="1168"/>

--- a/KeepingYouAwake/Preferences/Updates/KYAUpdatePreferencesViewController.h
+++ b/KeepingYouAwake/Preferences/Updates/KYAUpdatePreferencesViewController.h
@@ -7,10 +7,11 @@
 //
 
 #import <Cocoa/Cocoa.h>
+#import <Sparkle/Sparkle.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface KYAUpdatePreferencesViewController : NSViewController
+@interface KYAUpdatePreferencesViewController : NSViewController <SPUUpdaterDelegate>
 @end
 
 NS_ASSUME_NONNULL_END

--- a/KeepingYouAwake/Preferences/Updates/KYAUpdatePreferencesViewController.m
+++ b/KeepingYouAwake/Preferences/Updates/KYAUpdatePreferencesViewController.m
@@ -8,10 +8,25 @@
 
 #import "KYAUpdatePreferencesViewController.h"
 #import "KYADefines.h"
-
-@interface KYAUpdatePreferencesViewController ()
-
-@end
+#import "NSUserDefaults+Keys.h"
 
 @implementation KYAUpdatePreferencesViewController
+
+#pragma mark - SPUUpdaterDelegate
+
+- (NSString *)feedURLStringForUpdater:(SPUUpdater *)updater
+{
+    NSString *feedURLString = NSBundle.mainBundle.infoDictionary[@"SUFeedURL"];
+    NSAssert(feedURLString != nil, @"A feed URL should be set in Info.plist");
+    
+    if([NSUserDefaults.standardUserDefaults kya_arePreReleaseUpdatesEnabled])
+    {
+        NSString *lastComponent = feedURLString.lastPathComponent;
+        NSString *baseURLString = feedURLString.stringByDeletingLastPathComponent;
+        return [NSString stringWithFormat:@"%@/prerelease-%@", baseURLString, lastComponent];
+    }
+    
+    return feedURLString;
+}
+
 @end

--- a/Vendor/Makefile
+++ b/Vendor/Makefile
@@ -27,10 +27,9 @@ $(DIST_DIR): $(REPO_DIR)
 		build
 	cd $(DIST_DIR) && tar xfvj ../$(BUILD_DIR)/build/Build/Products/Release/Sparkle-*.tar.bz2
 
-	# Codesign Updater Binaries
-	$(CODESIGN_CMD) --deep "$(DIST_DIR)/Sparkle.framework/Versions/A/Resources/Autoupdate"
-	$(CODESIGN_CMD) --deep "$(DIST_DIR)/Sparkle.framework/Versions/A/Resources/Updater.app"
-	$(CODESIGN_CMD) "$(DIST_DIR)/Sparkle.framework/Versions/A"
+	# Remove Redundant Updater Binaries
+	$(RM) $(DIST_DIR)/Sparkle.framework/Versions/A/Resources/Autoupdate
+	$(RM) -r $(DIST_DIR)/Sparkle.framework/Versions/A/Resources/Updater.app
 
 	# Codesign XPC Services
 	patch $(DIST_DIR)/bin/codesign_xpc < codesign_xpc_hardened.patch


### PR DESCRIPTION
- restores the ability to check for pre-releases from the Preferences window
- strip `Autoupdate` and `Updater.app` from the `Sparkle.framework`
  - those don't work in a sandboxed world and are also embedded in the downloader XPC service