### PR TITLE
Advanced Setting: Quit when activation duration is over

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Changelog ##
 
+### v1.5.1 ###
+- added an advanced preference to quit the app when the activation duration is over ([#133](https://github.com/newmarcel/KeepingYouAwake/pull/133))
+	- _Thanks [jamesgecko](https://github.com/jamesgecko) for the [suggestion](https://github.com/newmarcel/KeepingYouAwake/issues/128)!_
+
+**Please note: The 1.5.x series of releases will be the last supporting macOS Yosemite and El Capitan. If you see any critical reason for supporting those, please leave a comment on [GitHub](https://github.com/newmarcel/KeepingYouAwake/issues/126).**
+
 ### v1.5.0 ###
 
 - added an _Updates_ tab to _Preferences_ ([#107](https://github.com/newmarcel/KeepingYouAwake/pull/107))

--- a/KeepingYouAwake/Extensions/NSUserDefaults+Keys.h
+++ b/KeepingYouAwake/Extensions/NSUserDefaults+Keys.h
@@ -15,6 +15,7 @@ FOUNDATION_EXPORT NSString * const KYAUserDefaultsKeyActivateOnLaunch;
 FOUNDATION_EXPORT NSString * const KYAUserDefaultsKeyNotificationsEnabled;
 FOUNDATION_EXPORT NSString * const KYAUserDefaultsKeyDefaultTimeInterval;
 FOUNDATION_EXPORT NSString * const KYAUserDefaultsKeyMenuBarIconHighlightDisabled;
+FOUNDATION_EXPORT NSString * const KYAUserDefaultsKeyIsQuitOnTimerExpirationEnabled;
 FOUNDATION_EXPORT NSString * const KYAUserDefaultsKeyBatteryCapacityThresholdEnabled;
 FOUNDATION_EXPORT NSString * const KYAUserDefaultsKeyBatteryCapacityThreshold;
 FOUNDATION_EXPORT NSString * const KYAUserDefaultsKeyPreReleaseUpdatesEnabled;
@@ -57,6 +58,11 @@ FOUNDATION_EXPORT NSString * const KYAUserDefaultsKeyPreReleaseUpdatesEnabled;
  Returns YES if Sparkle should check for pre-release updates.
  */
 @property (nonatomic, getter = kya_arePreReleaseUpdatesEnabled) BOOL kya_preReleaseUpdatesEnabled;
+
+/**
+ Returns YES if the app should quit when the sleep wake timer expires.
+ */
+@property (nonatomic, getter=kya_isQuitOnTimerExpirationEnabled) BOOL kya_quitOnTimerExpirationEnabled;
 
 @end
 

--- a/KeepingYouAwake/Extensions/NSUserDefaults+Keys.m
+++ b/KeepingYouAwake/Extensions/NSUserDefaults+Keys.m
@@ -13,6 +13,7 @@ NSString * const KYAUserDefaultsKeyActivateOnLaunch = @"info.marcel-dierkes.Keep
 NSString * const KYAUserDefaultsKeyNotificationsEnabled = @"info.marcel-dierkes.KeepingYouAwake.NotificationsEnabled";
 NSString * const KYAUserDefaultsKeyDefaultTimeInterval = @"info.marcel-dierkes.KeepingYouAwake.TimeInterval";
 NSString * const KYAUserDefaultsKeyMenuBarIconHighlightDisabled = @"info.marcel-dierkes.KeepingYouAwake.MenuBarIconHighlightDisabled";
+NSString * const KYAUserDefaultsKeyIsQuitOnTimerExpirationEnabled = @"info.marcel-dierkes.KeepingYouAwake.QuitOnTimerExpirationEnabled";
 
 NSString * const KYAUserDefaultsKeyBatteryCapacityThresholdEnabled = @"info.marcel-dierkes.KeepingYouAwake.BatteryCapacityThresholdEnabled";
 NSString * const KYAUserDefaultsKeyBatteryCapacityThreshold = @"info.marcel-dierkes.KeepingYouAwake.BatteryCapacityThreshold";
@@ -23,6 +24,7 @@ NSString * const KYAUserDefaultsKeyPreReleaseUpdatesEnabled = @"info.marcel-dier
 @dynamic kya_menuBarIconHighlightDisabled;
 @dynamic kya_batteryCapacityThresholdEnabled, kya_batteryCapacityThreshold;
 @dynamic kya_preReleaseUpdatesEnabled;
+@dynamic kya_quitOnTimerExpirationEnabled;
 
 #pragma mark - Activate on Launch
 
@@ -105,6 +107,18 @@ NSString * const KYAUserDefaultsKeyPreReleaseUpdatesEnabled = @"info.marcel-dier
 - (void)setKya_preReleaseUpdatesEnabled:(BOOL)preReleaseUpdatesEnabled
 {
     [self setBool:preReleaseUpdatesEnabled forKey:KYAUserDefaultsKeyPreReleaseUpdatesEnabled];
+}
+
+#pragma mark - Quit on Timer Expiration Enabled
+
+- (BOOL)kya_isQuitOnTimerExpirationEnabled
+{
+    return [self boolForKey:KYAUserDefaultsKeyIsQuitOnTimerExpirationEnabled];
+}
+
+- (void)setKya_quitOnTimerExpirationEnabled:(BOOL)quitOnTimerExpirationEnabled
+{
+    [self setBool:quitOnTimerExpirationEnabled forKey:KYAUserDefaultsKeyIsQuitOnTimerExpirationEnabled];
 }
 
 @end

--- a/KeepingYouAwake/KYAAppController.m
+++ b/KeepingYouAwake/KYAAppController.m
@@ -131,26 +131,34 @@
         return;
     }
 
+    KYA_AUTO defaults = NSUserDefaults.standardUserDefaults;
+
     // Check battery overrides and register for capacity changes.
     [self checkAndEnableBatteryOverride];
-    if([NSUserDefaults.standardUserDefaults kya_isBatteryCapacityThresholdEnabled])
+    if([defaults kya_isBatteryCapacityThresholdEnabled])
     {
         [self.batteryStatus registerForCapacityChangesIfNeeded];
     }
 
     KYA_AUTO timerCompletion = ^(BOOL cancelled) {
         // Post notifications
-        if([NSUserDefaults.standardUserDefaults kya_areNotificationsEnabled])
+        if([defaults kya_areNotificationsEnabled])
         {
             NSUserNotification *n = [NSUserNotification new];
             n.informativeText = KYA_L10N_ALLOWING_YOUR_MAC_TO_GO_TO_SLEEP;
             [NSUserNotificationCenter.defaultUserNotificationCenter scheduleNotification:n];
         }
+
+        // Quit on timer expiration
+        if(cancelled == NO && [defaults kya_isQuitOnTimerExpirationEnabled])
+        {
+            [NSApplication.sharedApplication terminate:nil];
+        }
     };
     [self.sleepWakeTimer scheduleWithTimeInterval:timeInterval completion:timerCompletion];
 
     // Post notifications
-    if([NSUserDefaults.standardUserDefaults kya_areNotificationsEnabled])
+    if([defaults kya_areNotificationsEnabled])
     {
         NSUserNotification *n = [NSUserNotification new];
 

--- a/KeepingYouAwake/KYALocalizedStrings.h
+++ b/KeepingYouAwake/KYALocalizedStrings.h
@@ -23,5 +23,6 @@
 
 #define KYA_L10N_ENABLE_EXPERIMENTAL_NOTIFICATION_CENTER_INTEGRATION NSLocalizedString(@"Enable experimental Notification Center integration", @"Enable experimental Notification Center integration")
 #define KYA_L10N_DISABLE_MENU_BAR_ICON_HIGHLIGHT_COLOR NSLocalizedString(@"Disable menu bar icon highlight color", @"Disable menu bar icon highlight color")
+#define KYA_L10N_QUIT_ON_TIMER_EXPIRATION NSLocalizedString(@"Quit when activation duration is over", @"Quit when activation duration is over")
 
 #endif /* KYA_LOCALIZED_STRINGS_H */

--- a/KeepingYouAwake/Preferences/Advanced/KYAAdvancedPreferencesViewController.m
+++ b/KeepingYouAwake/Preferences/Advanced/KYAAdvancedPreferencesViewController.m
@@ -52,6 +52,9 @@
     [preferences addObject:[[KYAPreference alloc] initWithTitle:KYA_L10N_DISABLE_MENU_BAR_ICON_HIGHLIGHT_COLOR
                                                     defaultsKey:KYAUserDefaultsKeyMenuBarIconHighlightDisabled
                             ]];
+    [preferences addObject:[[KYAPreference alloc] initWithTitle:KYA_L10N_QUIT_ON_TIMER_EXPIRATION
+                                                    defaultsKey:KYAUserDefaultsKeyIsQuitOnTimerExpirationEnabled
+                            ]];
     
     self.preferences = [preferences copy];
 }


### PR DESCRIPTION
Added an advanced preference to quit the app when the activation duration is over.

As wished in #128.