### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://keepingyouawake.app/
 
 **[Download the latest version here.](https://github.com/newmarcel/KeepingYouAwake/releases/latest)**
 
-or install it via [cask](http://caskroom.github.io/): `brew cask install keepingyouawake`.
+or install it via [cask](http://caskroom.github.io/): `brew install --cask keepingyouawake`.
 
 <img src="./Extras/Screenshot@2x.jpg" width="500" />
 


### PR DESCRIPTION
Fix error when installing using latest Homebrew. This is not a bug of this app, but README.md needs to be fixed.

screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103194664-ad977780-4923-11eb-89b2-3f7d3f4e00a8.png)
