### PR TITLE
Minor wording correction to da.xliff

### DIFF
--- a/Localizations/KeepingYouAwake/da.xcloc/Localized Contents/da.xliff
+++ b/Localizations/KeepingYouAwake/da.xcloc/Localized Contents/da.xliff
@@ -165,6 +165,7 @@ Højreklik for at vise menu</target>
       </trans-unit>
       <trans-unit id="Activation Duration" xml:space="preserve">
         <source>Activation Duration</source>
+        <targetAktiveringstid></target>
         <note/>
       </trans-unit>
       <trans-unit id="Advanced" xml:space="preserve">

--- a/Localizations/KeepingYouAwake/da.xcloc/Localized Contents/da.xliff
+++ b/Localizations/KeepingYouAwake/da.xcloc/Localized Contents/da.xliff
@@ -27,7 +27,7 @@
       </trans-unit>
       <trans-unit id="Activate for Duration" xml:space="preserve">
         <source>Activate for Duration</source>
-        <target>Aktivér varighed</target>
+        <target>Aktiveringstid</target>
         <note>Activate for Duration</note>
       </trans-unit>
       <trans-unit id="Afterwards your Mac will automatically go to sleep again when unused." xml:space="preserve">


### PR DESCRIPTION
'Activate for Duration' shows in english in the preferences window. I thought I missed a line of translation - but actually it was translated. Now also corrected in wording.