### PR TITLE
Fix Chinese translations for "Activate for Duration" menu item

### DIFF
--- a/KeepingYouAwake/Localizable.xcstrings
+++ b/KeepingYouAwake/Localizable.xcstrings
@@ -222,7 +222,7 @@
         "zh" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在一段时间内启动\t"
+            "value" : "激活时长"
           }
         },
         "zh-Hant" : {

--- a/Localizations/KeepingYouAwake/zh.xcloc/Localized Contents/zh.xliff
+++ b/Localizations/KeepingYouAwake/zh.xcloc/Localized Contents/zh.xliff
@@ -27,7 +27,7 @@
       </trans-unit>
       <trans-unit id="Activate for Duration" xml:space="preserve">
         <source>Activate for Duration</source>
-        <target state="translated">在一段时间内启动	</target>
+        <target state="translated">激活时长</target>
         <note>Activate for Duration</note>
       </trans-unit>
       <trans-unit id="Activate when an external display is connected" xml:space="preserve">


### PR DESCRIPTION
### Chinese Translation Update

**Original English:** Activate for Duration  
**Previous Chinese:** 在一段时间内启动  
**New Chinese:** 激活时长  

#### Context
In the app’s menu, this option lets users choose how long the app remains active (e.g., 5 minutes, 1 hour, or unlimited).

#### Reasoning
The previous translation “在一段时间内启动” literally means “start within a period of time,” which sounds like scheduling an activation.  
However, this option defines **how long the screen remains active**, not **when it turns on**.  

The updated translation “激活时长” is clearer, more natural, and better describes the intended behavior.
