### PR TITLE
Add option to allow displays to sleep to menubar

### DIFF
--- a/KeepingYouAwake/KYAAppController/KYAAppDelegate.m
+++ b/KeepingYouAwake/KYAAppController/KYAAppDelegate.m
@@ -68,4 +68,27 @@
     [settingsWindow makeKeyAndOrderFront:sender];
 }
 
+#pragma mark - Menu Actions
+
+- (void)toggleAllowDisplaySleep:(id)sender
+{
+    Auto defaults = NSUserDefaults.standardUserDefaults;
+    BOOL currentValue = [defaults kya_shouldAllowDisplaySleep];
+    [defaults setKya_allowDisplaySleep:!currentValue];
+    [defaults synchronize];
+}
+
+- (BOOL)validateMenuItem:(NSMenuItem *)menuItem
+{
+    if(menuItem.action == @selector(toggleAllowDisplaySleep:))
+    {
+        Auto defaults = NSUserDefaults.standardUserDefaults;
+        BOOL allowDisplaySleep = [defaults kya_shouldAllowDisplaySleep];
+        menuItem.state = allowDisplaySleep ? NSControlStateValueOn : NSControlStateValueOff;
+        return YES;
+    }
+
+    return YES;
+}
+
 @end

--- a/KeepingYouAwake/KYAMainMenu/KYAMainMenu.m
+++ b/KeepingYouAwake/KYAMainMenu/KYAMainMenu.m
@@ -26,7 +26,15 @@ NSMenu *KYACreateMainMenuWithActivationDurationsSubMenu(NSMenu *activationDurati
     }
     activateForDuration.submenu = activationDurationsSubMenu;
     [mainMenu addItem:activateForDuration];
-    
+
+    [mainMenu addItem:NSMenuItem.separatorItem];
+
+    Auto allowDisplaySleep = [[NSMenuItem alloc] initWithTitle:KYA_L10N_ALLOW_DISPLAY_SLEEP
+                                                       action:@selector(toggleAllowDisplaySleep:)
+                                                keyEquivalent:@""];
+    allowDisplaySleep.target = NSApplication.sharedApplication.delegate;
+    [mainMenu addItem:allowDisplaySleep];
+
     [mainMenu addItem:NSMenuItem.separatorItem];
     
     Auto settings = [[NSMenuItem alloc] initWithTitle:KYA_L10N_SETTINGS_ELLIPSIS


### PR DESCRIPTION
Sometimes, we just want to let the displays sleep in a quick, fast, and easy way. 🙂

<img width="302" height="185" alt="image" src="https://github.com/user-attachments/assets/89d5a8a6-3d80-4070-80a8-c5908a2502bf" />
