### PR TITLE
fix: Clamp battery capacity threshold to valid range

### DIFF
--- a/Packages/KYAApplicationSupport/Sources/KYAApplicationSupport/NSUserDefaults+KYAKeys.m
+++ b/Packages/KYAApplicationSupport/Sources/KYAApplicationSupport/NSUserDefaults+KYAKeys.m
@@ -87,7 +87,9 @@ NSString * const KYAUserDefaultsKeyBatteryCapacityThreshold = @"info.marcel-dier
 
 - (void)setKya_batteryCapacityThreshold:(CGFloat)batteryCapacityThreshold
 {
-    [self setFloat:(float)batteryCapacityThreshold forKey:KYAUserDefaultsKeyBatteryCapacityThreshold];
+    // Clamp value between 10% and 100%
+    CGFloat clampedThreshold = MIN(100.0f, MAX(10.0f, batteryCapacityThreshold));
+    [self setFloat:(float)clampedThreshold forKey:KYAUserDefaultsKeyBatteryCapacityThreshold];
 }
 
 @end

--- a/Packages/KYAApplicationSupport/Tests/KYAApplicationSupportTests/KYAUserDefaultsKeysTests.m
+++ b/Packages/KYAApplicationSupport/Tests/KYAApplicationSupportTests/KYAUserDefaultsKeysTests.m
@@ -90,18 +90,18 @@ KYA_GENERATE_BOOL_TEST(isLowPowerModeMonitoringEnabled,
     [defaults setFloat:50.0f forKey:key];
     XCTAssertEqual([defaults kya_batteryCapacityThreshold], 50.0f);
     
-    // Below 10%
+    // Below 10% - should clamp to 10%
     defaults.kya_batteryCapacityThreshold = 0.1f;
     XCTAssertEqual([defaults kya_batteryCapacityThreshold], 10.0f);
-    XCTAssertEqual([defaults floatForKey:key], 0.1f); // TODO: Maybe the setter should catch this?
+    XCTAssertEqual([defaults floatForKey:key], 10.0f); // Setter now clamps the value
     
     [defaults setFloat:0.2f forKey:key];
     XCTAssertEqual([defaults kya_batteryCapacityThreshold], 10.0f);
     
-    // Over 100%
-    defaults.kya_batteryCapacityThreshold = 512.0f; // TODO: Maybe this should be invalid?
-    XCTAssertEqual([defaults kya_batteryCapacityThreshold], 512.0f);
-    XCTAssertEqual([defaults floatForKey:key], 512.0f);
+    // Over 100% - should clamp to 100%
+    defaults.kya_batteryCapacityThreshold = 512.0f;
+    XCTAssertEqual([defaults kya_batteryCapacityThreshold], 100.0f); // Clamped to 100%
+    XCTAssertEqual([defaults floatForKey:key], 100.0f); // Setter now clamps the value
 }
 
 @end


### PR DESCRIPTION
- Add validation in setter to clamp between 10% and 100%
- Update tests to reflect new clamping behavior
- Resolves TODOs in KYAUserDefaultsKeysTests

This prevents invalid threshold values from being stored, ensuring the battery monitoring feature works correctly.