### PR TITLE
fix: Replace deprecated launchApplication with modern API

### DIFF
--- a/KYALauncher/KYAAppDelegate.m
+++ b/KYALauncher/KYAAppDelegate.m
@@ -17,9 +17,26 @@
     pathComponents = [pathComponents subarrayWithRange:pathRange];
 
     NSString *path = [NSString pathWithComponents:pathComponents];
-    [NSWorkspace.sharedWorkspace launchApplication:path];
-
-    [NSApplication.sharedApplication terminate:nil];
+    NSURL *appURL = [NSURL fileURLWithPath:path];
+    
+    if(@available(macOS 11.0, *))
+    {
+        NSWorkspaceOpenConfiguration *configuration = [NSWorkspaceOpenConfiguration configuration];
+        [NSWorkspace.sharedWorkspace openApplicationAtURL:appURL
+                                            configuration:configuration
+                                        completionHandler:^(NSRunningApplication *app, NSError *error) {
+            [NSApplication.sharedApplication terminate:nil];
+        }];
+    }
+    else
+    {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        [NSWorkspace.sharedWorkspace launchApplication:path];
+#pragma clang diagnostic pop
+        [NSApplication.sharedApplication terminate:nil];
+    }
 }
 
 @end
+


### PR DESCRIPTION
- Use openApplicationAtURL:configuration:completionHandler: for macOS 11+
- Keep backward compatibility with launchApplication for older systems
- Suppress deprecation warning for legacy code path

This fixes the deprecation warning in KeepingYouAwake Launcher.