### PR TITLE
Add missing Korean (ko) translations

### DIFF
--- a/KeepingYouAwake/Localizable.xcstrings
+++ b/KeepingYouAwake/Localizable.xcstrings
@@ -58,6 +58,12 @@
             "value" : "(Predefinito)"
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(기본값)"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -272,6 +278,12 @@
             "value" : "बाहरी डिस्प्ले कनेक्ट होने पर सक्रिय करें"
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "외부 디스플레이가 연결되면 활성화"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -365,6 +377,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Successivamente il tuo Mac andrà automaticamente in stop quando non usato."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이후 Mac은 사용하지 않을 때 자동으로 다시 잠자기 모드로 전환됩니다."
           }
         },
         "ru" : {
@@ -462,6 +480,12 @@
             "value" : "Consenti allo schermo di andare in stop"
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "디스플레이 잠자기 허용"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -555,6 +579,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stop consentito"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "잠자기 허용 중"
           }
         },
         "ru" : {
@@ -656,6 +686,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Annulla"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "취소"
           }
         },
         "ru" : {
@@ -999,6 +1035,12 @@
             "value" : "अन्य उपयोगकर्ता खाते पर स्विच करने पर निष्क्रिय करें"
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다른 사용자 계정으로 전환 시 비활성화"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1100,6 +1142,12 @@
             "value" : "Predefinito"
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기본값"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1199,6 +1247,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vuoi veramente reimposare le durate di attivazione ai valori di default?"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "활성 기간을 기본값으로 재설정하시겠습니까?"
           }
         },
         "ru" : {
@@ -1427,6 +1481,12 @@
             "value" : "OK"
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "확인"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1508,6 +1568,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stop prevenuto"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "잠자기 방지 중"
           }
         },
         "ru" : {
@@ -1603,6 +1669,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stop prevenuto per %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 동안 잠자기 방지 중"
           }
         },
         "ru" : {
@@ -1837,6 +1909,12 @@
             "value" : "Chiudi alla scadenza della durata"
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "활성 기간이 끝나면 종료"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1938,6 +2016,12 @@
             "value" : "Ripristina le durate"
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "활성 기간 재설정"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2037,6 +2121,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Imposta predefinito: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기본값으로 설정: %@"
           }
         },
         "ru" : {
@@ -2271,6 +2361,12 @@
             "value" : "La durata inserita non è valida. Per favore riprova."
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "입력한 기간이 올바르지 않습니다. 다시 시도해 주세요."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2370,6 +2466,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Questa durata è già stata aggiunta."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 기간은 이미 추가되어 있습니다."
           }
         },
         "ru" : {
@@ -2598,6 +2700,12 @@
             "value" : "Puoi comunque abilitare manualmente la modalità di stop per il tuo Mac."
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mac의 잠자기 모드를 수동으로 활성화할 수 있습니다."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2691,6 +2799,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il tuo Mac andrà automaticamente in stop quando non usato."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mac은 사용하지 않을 때 자동으로 잠자기 모드로 전환됩니다."
           }
         },
         "ru" : {

--- a/KeepingYouAwake/Settings/KYABatterySettingsViewController/mul.lproj/KYABatterySettingsViewController.xcstrings
+++ b/KeepingYouAwake/Settings/KYABatterySettingsViewController/mul.lproj/KYABatterySettingsViewController.xcstrings
@@ -707,6 +707,12 @@
             "value" : "लो पावर मोड सक्षम होने पर निष्क्रिय करें"
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "저전력 모드가 켜지면 비활성화"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1053,6 +1059,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "लो पावर मोड समर्थित Mac पर सिस्टम प्राथमिकताएं › बैटरी में सक्षम किया जा सकता है और चार्जिंग के दौरान लागू नहीं होगा।"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "저전력 모드는 지원되는 Mac의 시스템 설정 › 배터리에서 활성화할 수 있습니다."
           }
         },
         "ru" : {

--- a/KeepingYouAwake/Settings/KYADurationSettingsViewController/mul.lproj/KYAAddDurationViewController.xcstrings
+++ b/KeepingYouAwake/Settings/KYADurationSettingsViewController/mul.lproj/KYAAddDurationViewController.xcstrings
@@ -71,6 +71,12 @@
             "value" : "時"
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시간"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -183,6 +189,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "キャンセル"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "취소"
           }
         },
         "ru" : {
@@ -347,6 +359,12 @@
             "value" : "分"
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "분"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -461,6 +479,12 @@
             "value" : "秒"
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "초"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -573,6 +597,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기간 추가"
           }
         },
         "ru" : {

--- a/KeepingYouAwake/Settings/KYADurationSettingsViewController/mul.lproj/KYADurationSettingsViewController.xcstrings
+++ b/KeepingYouAwake/Settings/KYADurationSettingsViewController/mul.lproj/KYADurationSettingsViewController.xcstrings
@@ -71,6 +71,12 @@
             "value" : "削除"
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "삭제"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -183,6 +189,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "デフォルトのアクティブ時間はメニューバーアイコンをクリックした際に使用されます"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메뉴 막대 아이콘을 클릭하면 기본 활성 기간이 사용됩니다."
           }
         },
         "ru" : {
@@ -299,6 +311,12 @@
             "value" : "デフォルトにする"
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기본값으로 설정"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -411,6 +429,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "リセット…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "재설정…"
           }
         },
         "ru" : {
@@ -527,6 +551,12 @@
             "value" : "削除"
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "삭제"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -641,6 +671,12 @@
             "value" : "追加"
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추가"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -753,6 +789,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "デフォルトにする"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기본값으로 설정"
           }
         },
         "ru" : {

--- a/KeepingYouAwake/Settings/KYAGeneralSettingsViewController/mul.lproj/KYAGeneralSettingsViewController.xcstrings
+++ b/KeepingYouAwake/Settings/KYAGeneralSettingsViewController/mul.lproj/KYAGeneralSettingsViewController.xcstrings
@@ -65,6 +65,12 @@
             "value" : "通知の設定…"
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알림 설정…"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",

--- a/KeepingYouAwake/Settings/KYASettings.xcstrings
+++ b/KeepingYouAwake/Settings/KYASettings.xcstrings
@@ -207,6 +207,12 @@
             "value" : "アクティブ時間"
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "활성 기간"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -866,6 +872,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "アップデート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "업데이트"
           }
         },
         "ru" : {


### PR DESCRIPTION
## Summary
- Add 36 missing Korean (ko) translations across 6 xcstrings localization files
- No existing translations were modified

## Changes
| File | Translations Added |
|------|-------------------|
| `Localizable.xcstrings` | 19 |
| `KYASettings.xcstrings` | 2 |
| `KYABatterySettingsViewController.xcstrings` | 2 |
| `KYAAddDurationViewController.xcstrings` | 5 |
| `KYADurationSettingsViewController.xcstrings` | 7 |
| `KYAGeneralSettingsViewController.xcstrings` | 1 |

## Test plan
- [ ] Verify Korean translations display correctly in the app with system language set to Korean
- [ ] Confirm no existing translations were modified