### PR TITLE
Restore activation state after restart

### DIFF
--- a/KeepingYouAwake/KYAAppController/KYAAppController.m
+++ b/KeepingYouAwake/KYAAppController/KYAAppController.m
@@ -13,10 +13,19 @@
 #import "KYABatteryCapacityThreshold.h"
 #import "KYAActivationDurationsMenuController.h"
 #import "KYAActivationUserNotification.h"
+#import <math.h>
+#import <sys/sysctl.h>
 
 // Deprecated!
 #define KYA_MINUTES(m) (m * 60.0f)
 #define KYA_HOURS(h) (h * 3600.0f)
+
+static NSString * const KYARestorableActivationStatePendingDefaultsKey = @"info.marcel-dierkes.KeepingYouAwake.RestorableActivationState.Pending";
+static NSString * const KYARestorableActivationStateWasScheduledDefaultsKey = @"info.marcel-dierkes.KeepingYouAwake.RestorableActivationState.WasScheduled";
+static NSString * const KYARestorableActivationStateTimeIntervalDefaultsKey = @"info.marcel-dierkes.KeepingYouAwake.RestorableActivationState.TimeInterval";
+static NSString * const KYARestorableActivationStateFireDateDefaultsKey = @"info.marcel-dierkes.KeepingYouAwake.RestorableActivationState.FireDate";
+static NSString * const KYARestorableActivationStateBootDateDefaultsKey = @"info.marcel-dierkes.KeepingYouAwake.RestorableActivationState.BootDate";
+static NSTimeInterval const KYASameBootDateTolerance = 1.0f;
 
 @interface KYAAppController () <KYAStatusItemControllerDataSource, KYAStatusItemControllerDelegate, KYAActivationDurationsMenuControllerDelegate, KYASleepWakeTimerDelegate>
 @property (nonatomic, readwrite) KYASleepWakeTimer *sleepWakeTimer;
@@ -104,7 +113,12 @@
     Auto sleepWakeTimer = [KYASleepWakeTimer new];
     sleepWakeTimer.delegate = self;
     self.sleepWakeTimer = sleepWakeTimer;
-    
+
+    if([self restoreActivationStateAfterRestartIfNeeded])
+    {
+        return;
+    }
+
     // Activate on launch if needed
     if([NSUserDefaults.standardUserDefaults kya_isActivatedOnLaunch])
     {
@@ -169,6 +183,133 @@
 - (NSTimeInterval)defaultTimeInterval
 {
     return NSUserDefaults.standardUserDefaults.kya_defaultTimeInterval;
+}
+
+#pragma mark - Restore Activation State After Restart
+
+- (BOOL)restoreActivationStateAfterRestartIfNeeded
+{
+    Auto defaults = NSUserDefaults.standardUserDefaults;
+    if([defaults kya_shouldRestoreActivationStateOnRestart] == NO)
+    {
+        [self clearRestorableActivationState];
+        return NO;
+    }
+
+    if([defaults boolForKey:KYARestorableActivationStatePendingDefaultsKey] == NO)
+    {
+        return NO;
+    }
+
+    id storedBootDate = [defaults objectForKey:KYARestorableActivationStateBootDateDefaultsKey];
+    if([storedBootDate isKindOfClass:NSDate.class] == NO || [self isCurrentSystemBootDateEqualToDate:storedBootDate])
+    {
+        [self clearRestorableActivationState];
+        return NO;
+    }
+
+    BOOL wasScheduled = [defaults boolForKey:KYARestorableActivationStateWasScheduledDefaultsKey];
+    NSTimeInterval timeInterval = [defaults doubleForKey:KYARestorableActivationStateTimeIntervalDefaultsKey];
+    NSDate *fireDate = nil;
+
+    id storedFireDate = [defaults objectForKey:KYARestorableActivationStateFireDateDefaultsKey];
+    if([storedFireDate isKindOfClass:NSDate.class])
+    {
+        fireDate = storedFireDate;
+    }
+
+    [self clearRestorableActivationState];
+
+    if(wasScheduled == NO || timeInterval < 0)
+    {
+        return YES;
+    }
+
+    NSTimeInterval restoreTimeInterval = timeInterval;
+    if(fireDate != nil)
+    {
+        restoreTimeInterval = ceil(fireDate.timeIntervalSinceNow);
+        if(restoreTimeInterval <= 0)
+        {
+            return YES;
+        }
+    }
+
+    [self activateTimerWithTimeInterval:restoreTimeInterval];
+    return YES;
+}
+
+- (void)persistActivationStateForRestart
+{
+    Auto defaults = NSUserDefaults.standardUserDefaults;
+    if([defaults kya_shouldRestoreActivationStateOnRestart] == NO)
+    {
+        [self clearRestorableActivationState];
+        return;
+    }
+
+    Auto sleepWakeTimer = self.sleepWakeTimer;
+    BOOL wasScheduled = [sleepWakeTimer isScheduled];
+
+    [defaults setBool:YES forKey:KYARestorableActivationStatePendingDefaultsKey];
+    [defaults setBool:wasScheduled forKey:KYARestorableActivationStateWasScheduledDefaultsKey];
+    [defaults setObject:self.currentSystemBootDate forKey:KYARestorableActivationStateBootDateDefaultsKey];
+
+    if(wasScheduled)
+    {
+        [defaults setDouble:sleepWakeTimer.scheduledTimeInterval
+                    forKey:KYARestorableActivationStateTimeIntervalDefaultsKey];
+
+        Auto fireDate = sleepWakeTimer.fireDate;
+        if(fireDate != nil)
+        {
+            [defaults setObject:fireDate forKey:KYARestorableActivationStateFireDateDefaultsKey];
+        }
+        else
+        {
+            [defaults removeObjectForKey:KYARestorableActivationStateFireDateDefaultsKey];
+        }
+    }
+    else
+    {
+        [defaults removeObjectForKey:KYARestorableActivationStateTimeIntervalDefaultsKey];
+        [defaults removeObjectForKey:KYARestorableActivationStateFireDateDefaultsKey];
+    }
+
+    [defaults synchronize];
+}
+
+- (void)clearRestorableActivationState
+{
+    Auto defaults = NSUserDefaults.standardUserDefaults;
+    [defaults removeObjectForKey:KYARestorableActivationStatePendingDefaultsKey];
+    [defaults removeObjectForKey:KYARestorableActivationStateWasScheduledDefaultsKey];
+    [defaults removeObjectForKey:KYARestorableActivationStateTimeIntervalDefaultsKey];
+    [defaults removeObjectForKey:KYARestorableActivationStateFireDateDefaultsKey];
+    [defaults removeObjectForKey:KYARestorableActivationStateBootDateDefaultsKey];
+    [defaults synchronize];
+}
+
+- (NSDate *)currentSystemBootDate
+{
+    struct timeval bootTime;
+    size_t bootTimeSize = sizeof(bootTime);
+    int result = sysctlbyname("kern.boottime", &bootTime, &bootTimeSize, NULL, 0);
+    if(result == 0 && bootTime.tv_sec > 0)
+    {
+        NSTimeInterval seconds = (NSTimeInterval)bootTime.tv_sec + ((NSTimeInterval)bootTime.tv_usec / 1000000.0f);
+        return [NSDate dateWithTimeIntervalSince1970:seconds];
+    }
+
+    return [NSDate dateWithTimeIntervalSinceNow:-NSProcessInfo.processInfo.systemUptime];
+}
+
+- (BOOL)isCurrentSystemBootDateEqualToDate:(NSDate *)date
+{
+    NSParameterAssert(date);
+
+    NSTimeInterval distance = fabs([self.currentSystemBootDate timeIntervalSinceDate:date]);
+    return distance < KYASameBootDateTolerance;
 }
 
 #pragma mark - Activate on Launch
@@ -299,6 +440,10 @@
                         selector:@selector(workspaceSessionDidResignActive:)
                             name:NSWorkspaceSessionDidResignActiveNotification
                           object:nil];
+    [workspaceCenter addObserver:self
+                        selector:@selector(workspaceWillPowerOff:)
+                            name:NSWorkspaceWillPowerOffNotification
+                          object:nil];
 }
 
 - (void)unregisterFromWorkspaceSessionNotifications
@@ -309,6 +454,9 @@
                              object:nil];
     [workspaceCenter removeObserver:self
                                name:NSWorkspaceSessionDidResignActiveNotification
+                             object:nil];
+    [workspaceCenter removeObserver:self
+                               name:NSWorkspaceWillPowerOffNotification
                              object:nil];
 }
 
@@ -330,6 +478,11 @@
         self.workspaceScheduledTimeInterval = self.sleepWakeTimer.scheduledTimeInterval;
         [self terminateTimer];
     }
+}
+
+- (void)workspaceWillPowerOff:(NSNotification *)notification
+{
+    [self persistActivationStateForRestart];
 }
 
 #pragma mark - Event Handling

--- a/KeepingYouAwake/KYALocalizedStrings.m
+++ b/KeepingYouAwake/KYALocalizedStrings.m
@@ -53,6 +53,7 @@
 #define KYA_L10N_ALLOW_DISPLAY_SLEEP NSLocalizedString(@"Allow the display to sleep", @"Allow the display to sleep")
 #define KYA_L10N_ACTIVATE_ON_EXTERNAL_DISPLAY NSLocalizedString(@"Activate when an external display is connected", @"Activate when an external display is connected")
 #define KYA_L10N_DEACTIVATE_ON_USER_SWITCH NSLocalizedString(@"Deactivate when switched to another user account", @"Deactivate when switched to another user account")
+#define KYA_L10N_RESTORE_ACTIVATION_AFTER_RESTART NSLocalizedString(@"Restore activation state after restart", @"Restore activation state after restart")
 #define KYA_L10N_DURATIONS_ALERT_REALLY_RESET_TITLE NSLocalizedString(@"Reset Activation Durations", @"Reset Activation Durations")
 #define KYA_L10N_DURATIONS_ALERT_REALLY_RESET_MESSAGE NSLocalizedString(@"Do you really want to reset the activation durations to the default values?", @"Do you really want to reset the activation durations to the default values?")
 

--- a/KeepingYouAwake/Localizable.xcstrings
+++ b/KeepingYouAwake/Localizable.xcstrings
@@ -1982,6 +1982,9 @@
         }
       }
     },
+    "Restore activation state after restart" : {
+      "comment" : "Restore activation state after restart"
+    },
     "Set Default: %@" : {
       "comment" : "Set Default: %@",
       "localizations" : {

--- a/KeepingYouAwake/Settings/KYAAdvancedSettingsViewController/KYAAdvancedSettingsViewController.m
+++ b/KeepingYouAwake/Settings/KYAAdvancedSettingsViewController/KYAAdvancedSettingsViewController.m
@@ -62,6 +62,7 @@
     [settings addObject:[[KYAUserDefaultsSetting alloc] initWithTitle:KYA_L10N_ALLOW_DISPLAY_SLEEP key:KYAUserDefaultsKeyAllowDisplaySleep]];
     [settings addObject:[[KYAUserDefaultsSetting alloc] initWithTitle:KYA_L10N_ACTIVATE_ON_EXTERNAL_DISPLAY key:KYAUserDefaultsKeyActivateOnExternalDisplayConnectedEnabled]];
     [settings addObject:[[KYAUserDefaultsSetting alloc] initWithTitle:KYA_L10N_DEACTIVATE_ON_USER_SWITCH key:KYAUserDefaultsKeyDeactivateOnUserSwitchEnabled]];
+    [settings addObject:[[KYAUserDefaultsSetting alloc] initWithTitle:KYA_L10N_RESTORE_ACTIVATION_AFTER_RESTART key:KYAUserDefaultsKeyRestoreActivationStateOnRestart]];
     
     self.settings = [settings copy];
 }

--- a/Packages/KYAApplicationSupport/Sources/KYAApplicationSupport/NSUserDefaults+KYAKeys.m
+++ b/Packages/KYAApplicationSupport/Sources/KYAApplicationSupport/NSUserDefaults+KYAKeys.m
@@ -75,6 +75,10 @@ KYA_GENERATE_BOOL_PROPERTY(isLowPowerModeMonitoringEnabled,
                            lowPowerModeMonitoringEnabled,
                            LowPowerModeMonitoringEnabled);
 
+KYA_GENERATE_BOOL_PROPERTY(shouldRestoreActivationStateOnRestart,
+                           restoreActivationStateOnRestart,
+                           RestoreActivationStateOnRestart);
+
 #pragma mark - Battery Capacity Threshold
 
 NSString * const KYAUserDefaultsKeyBatteryCapacityThreshold = @"info.marcel-dierkes.KeepingYouAwake.BatteryCapacityThreshold";

--- a/Packages/KYAApplicationSupport/Sources/KYAApplicationSupport/include/KYAApplicationSupport/NSUserDefaults+KYAKeys.h
+++ b/Packages/KYAApplicationSupport/Sources/KYAApplicationSupport/include/KYAApplicationSupport/NSUserDefaults+KYAKeys.h
@@ -22,6 +22,7 @@ KYA_EXPORT NSString * const KYAUserDefaultsKeyBatteryCapacityThresholdEnabled;
 KYA_EXPORT NSString * const KYAUserDefaultsKeyBatteryCapacityThreshold;
 KYA_EXPORT NSString * const KYAUserDefaultsKeyLowPowerModeMonitoringEnabled;
 KYA_EXPORT NSString * const KYAUserDefaultsKeyPreReleaseUpdatesEnabled;
+KYA_EXPORT NSString * const KYAUserDefaultsKeyRestoreActivationStateOnRestart;
 
 @interface NSUserDefaults (KYAKeys)
 
@@ -57,6 +58,9 @@ KYA_EXPORT NSString * const KYAUserDefaultsKeyPreReleaseUpdatesEnabled;
 
 /// Returns YES if the app should deactivate when the user account is switched.
 @property (nonatomic, getter=kya_isDeactivateOnUserSwitchEnabled) BOOL kya_deactivateOnUserSwitchEnabled;
+
+/// Returns YES if the app should restore the activation state after a restart.
+@property (nonatomic, getter=kya_shouldRestoreActivationStateOnRestart) BOOL kya_restoreActivationStateOnRestart;
 
 @end
 

--- a/Packages/KYAApplicationSupport/Tests/KYAApplicationSupportTests/KYAUserDefaultsKeysTests.m
+++ b/Packages/KYAApplicationSupport/Tests/KYAApplicationSupportTests/KYAUserDefaultsKeysTests.m
@@ -78,6 +78,10 @@ KYA_GENERATE_BOOL_TEST(isLowPowerModeMonitoringEnabled,
                        lowPowerModeMonitoringEnabled,
                        KYAUserDefaultsKeyLowPowerModeMonitoringEnabled);
 
+KYA_GENERATE_BOOL_TEST(shouldRestoreActivationStateOnRestart,
+                       restoreActivationStateOnRestart,
+                       KYAUserDefaultsKeyRestoreActivationStateOnRestart);
+
 - (void)testBatteryCapacityThreshold
 {
     Auto defaults = self.defaults;


### PR DESCRIPTION
## Summary
- Add an advanced setting to restore the previous activation state after a device restart.
- Persist activation state during workspace power-off and restore only when the system boot date changed.
- Restore timed activations using the original fire date, skipping restore if the timer already expired during restart.

## Tests
- `xcodebuild build -workspace KeepingYouAwake.xcworkspace -scheme KeepingYouAwake -configuration Debug -derivedDataPath build -disableAutomaticPackageResolution -onlyUsePackageVersionsFromResolvedFile CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -workspace KeepingYouAwake.xcworkspace -scheme KeepingYouAwake -derivedDataPath build -disableAutomaticPackageResolution -onlyUsePackageVersionsFromResolvedFile CODE_SIGNING_ALLOWED=NO`

## Disclosure
This PR was prepared with AI assistance using Codex at the request of the fork owner.